### PR TITLE
Remove hardlink, fixed reg key creation

### DIFF
--- a/Intune/Windows General/Create HKCU Reg Key and Values using Remediation/Remediate_reg_key.ps1
+++ b/Intune/Windows General/Create HKCU Reg Key and Values using Remediation/Remediate_reg_key.ps1
@@ -37,8 +37,9 @@ $typeMap = @{
 if (-not (Test-Path $regPath)) {
     try {
         Write-Host "Creating Reg Key"
-        New-Item -Path "HKU:\$sid\Software" -Name "cloudinfra.net" -Force | Out-Null
+        New-Item -Path $regPath -Force | Out-Null
         foreach ($key in $regValues.Keys) {
+            $value = $regValues[$key]
             New-ItemProperty -Path $regPath -Name $key -Value $value.Data -PropertyType $value.Type -Force | Out-Null
         }
         Exit 0

--- a/Intune/Windows General/Create HKLM Reg Key and Values using Remediations/Remediate_reg_key.ps1
+++ b/Intune/Windows General/Create HKLM Reg Key and Values using Remediations/Remediate_reg_key.ps1
@@ -29,7 +29,7 @@ $typeMap = @{
 if (-not (Test-Path $regPath)) {
     try {
         Write-Host "Creating Reg Key"
-        New-Item -Path HKLM:\Software -Name cloudinfra.net -Force | Out-Null
+        New-Item -Path $regPath -Force | Out-Null
         foreach ($key in $regValues.Keys) {
             $value = $regValues[$key]
             New-ItemProperty -Path $regPath -Name $key -Value $value.Data -PropertyType $value.Type -Force | Out-Null


### PR DESCRIPTION
In the current script, there is a direct reference of a registry path, which partially negates the point of storing it as a variable earlier in the script. This will remove the reference of the path, and instead reference the variable.

One other issue I noticed was that this script was always creating a sub-key called `System.Collections.Hashtable` under the main key I was creating. This also fixes that issue.